### PR TITLE
fix for Python 3.10: Use collections.abc.Mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+*~
+*.egg-info
 \.idea/
 \__pycache__/
-

--- a/smart_settings/dynamic.py
+++ b/smart_settings/dynamic.py
@@ -45,15 +45,15 @@ def fstring_in_json(format_string, namespace):
 
 def recursive_dynamic_json(nested_dict_or_list, namespace):
     "Evaluates each key in nested dict as an f-string within a given namespace"
-    if isinstance(nested_dict_or_list, collections.Mapping):
+    if isinstance(nested_dict_or_list, collections.abc.Mapping):
         for k, v in nested_dict_or_list.items():
-            if isinstance(v, collections.Mapping) or isinstance(v, list):
+            if isinstance(v, collections.abc.Mapping) or isinstance(v, list):
                 recursive_dynamic_json(v, namespace)
             else:
                 nested_dict_or_list[k] = fstring_in_json(v, namespace)
     elif isinstance(nested_dict_or_list, list):
         for i, item in enumerate(nested_dict_or_list):
-            if isinstance(item, collections.Mapping) or isinstance(item, list):
+            if isinstance(item, collections.abc.Mapping) or isinstance(item, list):
                 recursive_dynamic_json(item, namespace)
             else:
                 nested_dict_or_list[i] = fstring_in_json(item, namespace)

--- a/smart_settings/param_classes.py
+++ b/smart_settings/param_classes.py
@@ -74,7 +74,7 @@ def recursive_objectify(nested_dict, make_immutable=True):
     "Turns a nested_dict into a nested AttributeDict"
     result = deepcopy(nested_dict)
     for k, v in result.items():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, collections.abc.Mapping):
             result = dict(result)
             result[k] = recursive_objectify(v, make_immutable)
     if make_immutable:


### PR DESCRIPTION
Since Python 3.3 collections.Mapping is deprecated and collections.abc.Mapping should be used instead.  Since Python 3.10 only the latter works.