### PR TITLE
Add toml support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,12 +4,14 @@ A nifty little wrapper around settings files. Particularly useful for cluster ut
 
 ## Run to install:
 
-``python3 -m pip install git+https://gitlab.tuebingen.mpg.de/mrolinek/smart-json.git``
+```bash
+python3 -m pip install git+https://gitlab.tuebingen.mpg.de/mrolinek/smart-json.git
+```
 
 
 ## Main features
 
-* **JSON/YAML support** Both file formats are supported.
+* **Supports JSON, YAML and TOML files.**
 
 * **Duplicate check**. Duplicate keys in JSONs are caught and raise an exception.
 
@@ -21,21 +23,21 @@ A nifty little wrapper around settings files. Particularly useful for cluster ut
 
 ## API for changing keys in many files
 
-``
+```bash
 python3 -m smart_settings.change_key settings/*.json train_params.opt_params optimizer_params
-``
+```
 
 --> Changes `train_params.opt_params` to `train_params.optimizer_params` in every file matching the wildcard
 
-``
+```bash
 python3 -m smart_settings.add_key settings/*.json  train_params.num_epochs 10 --override
-``
+```
 
 --> Adds key `train_params.num_epochs` with value `10`. `--override` controls overwriting of present values
 
-``
+```bash
 python3 -m smart_settings.port_cluster_utils_3 settings/**/*.json
-``
+```
 
 --> Performs all name changes required for porting to `cluster_utils >=3.0`
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ setup(
     author_email="michalrolinek@gmail.com",
     license="MIT",
     packages=["smart_settings"],
-    install_requires=["pyyaml"],
+    install_requires=[
+        "pyyaml",
+        "tomli; python_version < '3.11'",
+    ],
     zip_safe=False,
 )

--- a/smart_settings/smart_settings.py
+++ b/smart_settings/smart_settings.py
@@ -3,22 +3,34 @@ import json
 from .param_classes import NoDuplicateDict, recursive_objectify, update_recursive
 from .dynamic import recursive_dynamic_json
 import collections.abc
+
+try:
+    import tomllib
+except ImportError:
+    # tomllib was added in Python 3.11.  Older versions can use tomli
+    import tomli as tomllib
 import yaml
+
 from .utils import removesuffix
 
 IMPORT_KEY = "__import__"
 
 
 def load_raw_dict_from_file(filename):
-    """Safe load of a json file (doubled entries raise exception)"""
+    """Safe load of a json/yaml/toml file (doubled entries raise exception)."""
     if filename.endswith(".json"):
         with open(filename, "r") as f:
             data = json.load(f, object_pairs_hook=NoDuplicateDict)
-        return data
     elif filename.endswith(".yaml"):
         with open(filename, "r") as f:
             data = yaml.safe_load(f)
-        return data
+    elif filename.endswith(".toml"):
+        with open(filename, "rb") as f:
+            data = tomllib.load(f)
+    else:
+        raise RuntimeError("Unsupported file type.")
+
+    return data
 
 
 def load(

--- a/smart_settings/smart_settings.py
+++ b/smart_settings/smart_settings.py
@@ -21,7 +21,7 @@ def load_raw_dict_from_file(filename):
     if filename.endswith(".json"):
         with open(filename, "r") as f:
             data = json.load(f, object_pairs_hook=NoDuplicateDict)
-    elif filename.endswith(".yaml"):
+    elif filename.endswith(".yaml") or filename.endswith(".yml"):
         with open(filename, "r") as f:
             data = yaml.safe_load(f)
     elif filename.endswith(".toml"):


### PR DESCRIPTION
TOML files are read to dictionaries just like JSON or YAML, so to support them as well.
TOML doesn't allow duplicate keys as per its standard, so no explicit check is needed for that.

The `tomllib` package was added in Python 3.11.  For older versions, the third-party package `tomli` can be used as replacement (`tomllib` is actually based on `tomli`, so they should be pretty compatible).

Also fixes a bug: `load_raw_dict_from_file()` now raises an error if an unsupported file type is passed.

## How I Tested
In combination with cluster_utils (converting an existing json config file to toml and running with that file).

## Do not merge before
- #4 